### PR TITLE
Add update-deps.sh for automation

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source $(dirname "$0")/../vendor/knative.dev/hack/library.sh
+
+go_update_deps "$@"


### PR DESCRIPTION
# Changes

- Adds `hack/update-deps.sh` script to enable automation to update dependencies. Added script is a copy of the one used by Serving.

/assign @julz @markusthoemmes 
