### PR TITLE
Tidy freeze functions a bit

### DIFF
--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -39,7 +39,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("unable to create containerd cri: %v", err)
 		}
-		freezeThaw, err = containerd.New(ctrd)
+		freezeThaw = containerd.New(ctrd)
 		// TODO support docker, crio
 	default:
 		log.Fatal("unrecognised runtimeType", runtimeType)

--- a/cmd/daemon/main.go
+++ b/cmd/daemon/main.go
@@ -35,7 +35,11 @@ func main() {
 	switch runtimeType {
 	case runtimeTypeContainerd:
 		logger.Info("creating new containerd freezeThawer")
-		freezeThaw, err = containerd.New(&containerd.ContainerdCRI{})
+		ctrd, err := containerd.NewCRI()
+		if err != nil {
+			log.Fatalf("unable to create containerd cri: %v", err)
+		}
+		freezeThaw, err = containerd.New(ctrd)
 		// TODO support docker, crio
 	default:
 		log.Fatal("unrecognised runtimeType", runtimeType)

--- a/pkg/freeze/containerd/pause.go
+++ b/pkg/freeze/containerd/pause.go
@@ -32,8 +32,8 @@ var ErrNoNonQueueProxyPods = errors.New("no non queue-proxy containers found in 
 
 // New return a FreezeThawer based on Containerd.
 // Requires /var/run/containerd/containerd.sock to be mounted.
-func New(c CRI) (*Containerd, error) {
-	return &Containerd{cri: c}, nil
+func New(c CRI) *Containerd {
+	return &Containerd{cri: c}
 }
 
 // NewCRI returns a CRI based on Containerd.

--- a/pkg/freeze/containerd/pause_test.go
+++ b/pkg/freeze/containerd/pause_test.go
@@ -5,8 +5,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/containerd/containerd"
-	"google.golang.org/grpc"
 	cri "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"knative.dev/container-freezer/pkg/daemon"
 )
@@ -28,7 +26,7 @@ func Container(id, name string) *cri.Container {
 	}
 }
 
-func (f *FakeContainerdCRI) List(ctx context.Context, conn *grpc.ClientConn, podUID string) ([]string, error) {
+func (f *FakeContainerdCRI) List(ctx context.Context, podUID string) ([]string, error) {
 	var containerList []string
 	for _, c := range f.containers {
 		if c.Metadata.Name != "queue-proxy" {
@@ -38,13 +36,13 @@ func (f *FakeContainerdCRI) List(ctx context.Context, conn *grpc.ClientConn, pod
 	return containerList, nil
 }
 
-func (f *FakeContainerdCRI) Pause(ctx context.Context, ctrd *containerd.Client, container string) error {
+func (f *FakeContainerdCRI) Pause(ctx context.Context, container string) error {
 	f.paused = append(f.paused, container)
 	f.method = "pause"
 	return nil
 }
 
-func (f *FakeContainerdCRI) Resume(ctx context.Context, ctrd *containerd.Client, container string) error {
+func (f *FakeContainerdCRI) Resume(ctx context.Context, container string) error {
 	f.resumed = append(f.resumed, container)
 	f.method = "resume"
 	return nil

--- a/pkg/freeze/containerd/pause_test.go
+++ b/pkg/freeze/containerd/pause_test.go
@@ -50,7 +50,6 @@ func (f *FakeContainerdCRI) Resume(ctx context.Context, container string) error 
 
 func TestContainerPause(t *testing.T) {
 	var fakeFreezeThawer daemon.FreezeThawer
-	var err error
 
 	tests := []struct {
 		containers    []*cri.Container
@@ -71,10 +70,7 @@ func TestContainerPause(t *testing.T) {
 			paused:     nil,
 			containers: c.containers,
 		}
-		fakeFreezeThawer, err = New(fakeContainerCRI)
-		if err != nil {
-			t.Errorf("expected New() to succeed but got %q", err)
-		}
+		fakeFreezeThawer = New(fakeContainerCRI)
 		if err := fakeFreezeThawer.Freeze(nil, ""); err != nil {
 			t.Errorf("expected freeze to succeed but failed: %v", err)
 		}
@@ -89,7 +85,6 @@ func TestContainerPause(t *testing.T) {
 
 func TestContainerResume(t *testing.T) {
 	var fakeFreezeThawer daemon.FreezeThawer
-	var err error
 
 	tests := []struct {
 		containers     []*cri.Container
@@ -110,10 +105,7 @@ func TestContainerResume(t *testing.T) {
 			resumed:    nil,
 			containers: c.containers,
 		}
-		fakeFreezeThawer, err = New(fakeContainerdCRI)
-		if err != nil {
-			t.Errorf("expected New() to succeed but got %q", err)
-		}
+		fakeFreezeThawer = New(fakeContainerdCRI)
 		if err := fakeFreezeThawer.Thaw(nil, ""); err != nil {
 			t.Errorf("expected thaw to succeed but failed: %v", err)
 		}

--- a/pkg/freeze/containerd/pause_test.go
+++ b/pkg/freeze/containerd/pause_test.go
@@ -28,8 +28,14 @@ func Container(id, name string) *cri.Container {
 	}
 }
 
-func (f *FakeContainerdCRI) List(ctx context.Context, conn *grpc.ClientConn, podUID string) (*cri.ListContainersResponse, error) {
-	return &cri.ListContainersResponse{Containers: f.containers}, nil
+func (f *FakeContainerdCRI) List(ctx context.Context, conn *grpc.ClientConn, podUID string) ([]string, error) {
+	var containerList []string
+	for _, c := range f.containers {
+		if c.Metadata.Name != "queue-proxy" {
+			containerList = append(containerList, c.Id)
+		}
+	}
+	return containerList, nil
 }
 
 func (f *FakeContainerdCRI) Pause(ctx context.Context, ctrd *containerd.Client, container string) error {


### PR DESCRIPTION
# Changes

Cleaning up the freezing functionality by:
* moving the containerd client creation into the CRI constructor
* having the List method return a list of containerIDs, rather than a list of containers (and then parsing the IDs in a separate step)

First change was originally suggested [here](https://github.com/knative-sandbox/container-freezer/pull/35#discussion_r764703534).

/assign @julz 