### PR TITLE
Update working group sponsor

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,12 @@
 approvers:
   - technical-oversight-committee
   - knative-release-leads
-  - serving-approvers
+  - serving-writers
   - container-freezer-approvers
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,
 # copy the approvers to the reviewers list too.
 reviewers:
-  - serving-approvers
+  - serving-writers
   - container-freezer-approvers

--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,12 @@
 approvers:
   - technical-oversight-committee
   - knative-release-leads
-  - autoscaling-wg-leads
+  - serving-approvers
   - container-freezer-approvers
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,
 # copy the approvers to the reviewers list too.
 reviewers:
-  - autoscaling-wg-leads
+  - serving-approvers
   - container-freezer-approvers

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 | STATUS | Sponsoring WG |
 | --- | --- |
-| Alpha | [Autoscaling](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#scaling)|
+| Alpha | [Serving](https://github.com/knative/community/blob/main/working-groups/WORKING-GROUPS.md#serving)|
 
 A standalone service for Knative to pause/unpause containers when request count drops to zero.
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

s/scaling/serving

As we've merged the Scaling WG into the Serving WG, Serving should get to acquire sponsorship of the freezer as well.

/assign @dprotaso 