### PR TITLE
Reduces codecov threshold

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -4,7 +4,7 @@ coverage:
   status:
     project:
       default:
-        target: 80
+        target: 65
         threshold: 1%
     patch:
       # Disable the coverage threshold of the patch, so that PRs are


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

# Changes

The current code coverage threshold of 80% was aspirational, and the test has been failing for so long that I think we mostly just ignore it. So this PR drops the code coverage threshold to 65%, which is about at the current level of coverage. 

This should prevent any slippage in coverage, and as we add more tests we can up the threshold.

/assign @nader-ziada 