### PR TITLE
drop k8s v1.22 e2e tests

### DIFF
--- a/.github/workflows/kind-e2e-containerd.yaml
+++ b/.github/workflows/kind-e2e-containerd.yaml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - v1.22.9
           - v1.23.6
           - v1.24.2
 
@@ -29,10 +28,6 @@ jobs:
         # This is attempting to make it a bit clearer what's being tested.
         # See: https://github.com/kubernetes-sigs/kind/releases
         include:
-          - k8s-version: v1.22.9
-            kind-version: v0.14.0
-            kind-image-sha: sha256:8135260b959dfe320206eb36b3aeda9cffcb262f4b44cda6b33f7bb73f453105
-
           - k8s-version: v1.23.6
             kind-version: v0.14.0
             kind-image-sha: sha256:b1fa224cc6c7ff32455e0b1fd9cbfd3d3bc87ecaa8fcb06961ed1afb3db0f9ae

--- a/.github/workflows/kubeadm-e2e-crio.yaml
+++ b/.github/workflows/kubeadm-e2e-crio.yaml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-          - 1.22.9
           - 1.23.6
           - 1.24.2
 


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paul@paulschweigert.com>

# Changes

Kubernetes v1.22 is no longer supported, so drop those e2e tests

/assign @jwcesign @nader-ziada 